### PR TITLE
Fetch order status

### DIFF
--- a/lib/baby-braspag/credit_card.rb
+++ b/lib/baby-braspag/credit_card.rb
@@ -199,14 +199,9 @@ module Braspag
 
         matches = params[:expiration].to_s.match /^(\d{2})\/(\d{2,4})$/
         raise InvalidExpirationDate unless matches
-        begin
-          year = matches[2].to_i
-          year = "20#{year}" if year.size == 2
 
-          Date.new(year.to_i, matches[1].to_i)
-        rescue ArgumentError
-          raise InvalidExpirationDate
-        end
+        year = matches[2].size == 4 ? matches[2] : "20#{matches[2]}"
+        raise if !Date.valid_date?(year.to_i, matches[1].to_i, 1)
 
         raise InvalidSecurityCode if params[:security_code].to_s.size < 1 || params[:security_code].to_s.size > 4
 

--- a/lib/baby-braspag/credit_card.rb
+++ b/lib/baby-braspag/credit_card.rb
@@ -21,7 +21,7 @@ module Braspag
     CANCELLATION_URI = "/webservices/pagador/Pagador.asmx/VoidTransaction"
     PRODUCTION_INFO_URI   = "/webservices/pagador/pedido.asmx/GetDadosCartao"
     HOMOLOGATION_INFO_URI = "/pagador/webservice/pedido.asmx/GetDadosCartao"
-    STATUS_URI = "/webservices/pagador/Pagador.asmx/GetDadosPedido"
+    STATUS_URI = "/webservices/pagador/pedido.asmx/GetDadosPedido"
 
     def self.authorize(params = {})
       connection = Braspag::Connection.instance
@@ -148,10 +148,7 @@ module Braspag
 
       raise InvalidOrderId unless self.valid_order_id?(order_id)
 
-      data = {
-        MAPPING[:order] => order_id,
-        MAPPING[:merchant_id] => connection.merchant_id
-      }
+      data = { :numeroPedido => order_id, :loja => connection.merchant_id }
 
       response = Braspag::Poster.new(status_url).do_post(:order_status, data)
 

--- a/lib/baby-braspag/credit_card.rb
+++ b/lib/baby-braspag/credit_card.rb
@@ -1,6 +1,5 @@
 module Braspag
   class CreditCard < PaymentMethod
-
     MAPPING = {
       :merchant_id => "merchantId",
       :order => 'order',
@@ -44,13 +43,13 @@ module Braspag
       response = Braspag::Poster.new(authorize_url).do_post(:authorize, data)
 
       Utils::convert_to_map(response.body, {
-          :amount => nil,
-          :number => "authorisationNumber",
-          :message => 'message',
-          :return_code => 'returnCode',
-          :status => 'status',
-          :transaction_id => "transactionId"
-        })
+        :amount => nil,
+        :number => "authorisationNumber",
+        :message => 'message',
+        :return_code => 'returnCode',
+        :status => 'status',
+        :transaction_id => "transactionId"
+      })
     end
 
     def self.capture(order_id)
@@ -67,13 +66,13 @@ module Braspag
       response = Braspag::Poster.new(capture_url).do_post(:capture, data)
 
       Utils::convert_to_map(response.body, {
-          :amount => nil,
-          :number => "authorisationNumber",
-          :message => 'message',
-          :return_code => 'returnCode',
-          :status => 'status',
-          :transaction_id => "transactionId"
-        })
+        :amount => nil,
+        :number => "authorisationNumber",
+        :message => 'message',
+        :return_code => 'returnCode',
+        :status => 'status',
+        :transaction_id => "transactionId"
+      })
     end
 
     def self.partial_capture(order_id, amount)
@@ -91,13 +90,13 @@ module Braspag
       response = Braspag::Poster.new(partial_capture_url).do_post(:partial_capture, data)
 
       Utils::convert_to_map(response.body, {
-          :amount => nil,
-          :number => "authorisationNumber",
-          :message => 'message',
-          :return_code => 'returnCode',
-          :status => 'status',
-          :transaction_id => "transactionId"
-        })
+        :amount => nil,
+        :number => "authorisationNumber",
+        :message => 'message',
+        :return_code => 'returnCode',
+        :status => 'status',
+        :transaction_id => "transactionId"
+      })
     end
 
     def self.void(order_id)
@@ -114,13 +113,13 @@ module Braspag
       response = Braspag::Poster.new(cancellation_url).do_post(:void, data)
 
       Utils::convert_to_map(response.body, {
-          :amount => nil,
-          :number => "authorisationNumber",
-          :message => 'message',
-          :return_code => 'returnCode',
-          :status => 'status',
-          :transaction_id => "transactionId"
-        })
+        :amount => nil,
+        :number => "authorisationNumber",
+        :message => 'message',
+        :return_code => 'returnCode',
+        :status => 'status',
+        :transaction_id => "transactionId"
+      })
     end
 
     def self.info(order_id)
@@ -132,12 +131,12 @@ module Braspag
       response = Braspag::Poster.new(info_url).do_post(:info_credit_card, data)
 
       response = Utils::convert_to_map(response.body, {
-          :checking_number => "NumeroComprovante",
-          :certified => "Autenticada",
-          :autorization_number => "NumeroAutorizacao",
-          :card_number => "NumeroCartao",
-          :transaction_number => "NumeroTransacao"
-        })
+        :checking_number => "NumeroComprovante",
+        :certified => "Autenticada",
+        :autorization_number => "NumeroAutorizacao",
+        :card_number => "NumeroCartao",
+        :transaction_number => "NumeroTransacao"
+      })
 
       raise UnknownError if response[:checking_number].nil?
       response

--- a/spec/credit_card_spec.rb
+++ b/spec/credit_card_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 require 'ostruct'
 
 describe Braspag::CreditCard do
-  let(:braspag_service_url) { "https://homologacao.pagador.com.br" }
+  let(:braspag_service_url) { 'https://homologacao.pagador.com.br' }
 
   let(:connection) { mock(
     :merchant_id => 'merchant-id',
@@ -30,13 +30,13 @@ describe Braspag::CreditCard do
 
     let(:params) { {
       :order_id => order_id,
-      :customer_name => "W" * 21,
-      :amount => "100.00",
+      :customer_name => 'W' * 21,
+      :amount => '100.00',
       :payment_method => :redecard,
-      :holder => "Joao Maria Souza",
-      :card_number => "9" * 10,
-      :expiration => "10/12",
-      :security_code => "123",
+      :holder => 'Joao Maria Souza',
+      :card_number => '9' * 10,
+      :expiration => '10/12',
+      :security_code => '123',
       :number_payments => 1,
       :type => 0
     } }
@@ -60,18 +60,31 @@ describe Braspag::CreditCard do
 
     it "request the order authorization" do
       Braspag::CreditCard.authorize(params)
-      request.body.should == {"merchantId"=>"merchant-id", "order"=>"", "orderId"=>"order-id", "customerName"=>"WWWWWWWWWWWWWWWWWWWWW", "amount"=>"100,00", "paymentMethod"=>997, "holder"=>"Joao Maria Souza", "cardNumber"=>"9999999999", "expiration"=>"10/12", "securityCode"=>"123", "numberPayments"=>1, "typePayment"=>0}
+      request.body.should == {
+        'merchantId' => 'merchant-id',
+        'order' => '',
+        'orderId' => 'order-id',
+        'customerName' => 'WWWWWWWWWWWWWWWWWWWWW',
+        'amount' => '100,00',
+        'paymentMethod' => 997,
+        'holder' => 'Joao Maria Souza',
+        'cardNumber' => '9999999999',
+        'expiration' => '10/12',
+        'securityCode' => '123',
+        'numberPayments' => 1,
+        'typePayment' => 0
+      }
     end
 
     it "returns the authorization result" do
       response = Braspag::CreditCard.authorize(params)
       response.should == {
-        :amount => "5",
-        :message => "Transaction Successful",
-        :number => "733610",
-        :return_code => "7",
-        :status => "2",
-        :transaction_id => "0"
+        :amount => '5',
+        :message => 'Transaction Successful',
+        :number => '733610',
+        :return_code => '7',
+        :status => '2',
+        :transaction_id => '0'
       }
     end
 
@@ -160,7 +173,7 @@ describe Braspag::CreditCard do
 
   describe ".capture" do
     let(:operation_url) { "#{connection.braspag_url}/webservices/pagador/Pagador.asmx/Capture" }
-    let(:order_id) { "order-id" }
+    let(:order_id) { 'order-id' }
 
     let(:response_xml) do
       <<-EOXML
@@ -177,18 +190,18 @@ describe Braspag::CreditCard do
     end
 
     it "requests the order capture" do
-      Braspag::CreditCard.capture("order id qualquer")
-      request.body.should == {"orderId"=>"order id qualquer", "merchantId"=>"merchant-id"}
+      Braspag::CreditCard.capture('order id qualquer')
+      request.body.should == { 'orderId' => 'order id qualquer', 'merchantId' => 'merchant-id' }
     end
 
     it "returns the capture result" do
-      response = Braspag::CreditCard.capture("order id qualquer")
+      response = Braspag::CreditCard.capture('order id qualquer')
       response.should == {
-        :amount => "2",
+        :amount => '2',
         :number => nil,
-        :message => "Approved",
-        :return_code => "0",
-        :status => "0",
+        :message => 'Approved',
+        :return_code => '0',
+        :status => '0',
         :transaction_id => nil
       }
     end
@@ -204,7 +217,7 @@ describe Braspag::CreditCard do
 
   describe ".partial_capture" do
     let(:operation_url) { "#{connection.braspag_url}/webservices/pagador/Pagador.asmx/CapturePartial" }
-    let(:order_id) { "order-id" }
+    let(:order_id) { 'order-id' }
 
     let(:response_xml) do
       <<-EOXML
@@ -222,17 +235,17 @@ describe Braspag::CreditCard do
 
     it "requests the order partial capture" do
       Braspag::CreditCard.partial_capture(order_id, 10.0)
-      request.body.should == {"orderId"=>"order-id", "captureAmount"=>"10,00", "merchantId"=>"merchant-id"}
+      request.body.should == { 'orderId' => 'order-id', 'captureAmount' => '10,00', 'merchantId' => 'merchant-id' }
     end
 
     it "returns the partial capture response" do
       response = Braspag::CreditCard.partial_capture(order_id, 10.0)
       response.should == {
-        :amount => "2",
+        :amount => '2',
         :number => nil,
-        :message => "Approved",
-        :return_code => "0",
-        :status => "0",
+        :message => 'Approved',
+        :return_code => '0',
+        :status => '0',
         :transaction_id => nil
       }
     end
@@ -266,17 +279,17 @@ describe Braspag::CreditCard do
 
     it "requests the order cancellation" do
       Braspag::CreditCard.void(order_id)
-      request.body.should == {"order"=>"order-id", "merchantId"=>"merchant-id"}
+      request.body.should == { 'order' => 'order-id', 'merchantId' => 'merchant-id' }
     end
 
     it "returns the cancellation response" do
       response = Braspag::CreditCard.void(order_id)
       response.should == {
-        :amount => "2",
+        :amount => '2',
         :number => nil,
-        :message => "Approved",
-        :return_code => "0",
-        :status => "0",
+        :message => 'Approved',
+        :return_code => '0',
+        :status => '0',
         :transaction_id => nil
       }
     end
@@ -311,11 +324,11 @@ describe Braspag::CreditCard do
     it "returns the credit card info response" do
       response = Braspag::CreditCard.info(order_id)
       response.should == {
-        :checking_number => "11111",
-        :certified => "false",
-        :autorization_number => "557593",
-        :card_number => "345678*****0007",
-        :transaction_number => "101001225645"
+        :checking_number => '11111',
+        :certified => 'false',
+        :autorization_number => '557593',
+        :card_number => '345678*****0007',
+        :transaction_number => '101001225645'
       }
     end
 
@@ -378,15 +391,15 @@ describe Braspag::CreditCard do
     it "returns the status response" do
       response = Braspag::CreditCard.status(order_id)
       response.should == {
-        :authorization_code=>"012543   ",
-        :payment_code=>"42",
-        :payment_method=>"Redecard Webservice PreAuth",
-        :installments=>"1",
-        :status=>"3",
-        :value=>"35.46",
-        :payment_date=>"2/28/2015 12:00:00 AM",
-        :order_date=>"2/28/2015 9:56:35 AM",
-        :transaction_id=>"0301122",
+        :authorization_code=>'012543   ',
+        :payment_code=>'42',
+        :payment_method=>'Redecard Webservice PreAuth',
+        :installments=>'1',
+        :status=>'3',
+        :value=>'35.46',
+        :payment_date=>'2/28/2015 12:00:00 AM',
+        :order_date=>'2/28/2015 9:56:35 AM',
+        :transaction_id=>'0301122',
         :error_code=>nil,
         :error_message=>nil
       }

--- a/spec/credit_card_spec.rb
+++ b/spec/credit_card_spec.rb
@@ -250,37 +250,35 @@ describe Braspag::CreditCard do
     let(:operation_url) { "#{connection.braspag_url}/webservices/pagador/Pagador.asmx/VoidTransaction" }
     let(:order_id) { 'order-id' }
 
-    context "valid order id" do
-      let(:response_xml) do
-        <<-EOXML
-          <?xml version="1.0" encoding="utf-8"?>
-          <PagadorReturn xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                         xmlns="https://www.pagador.com.br/webservice/pagador">
-            <amount>2</amount>
-            <message>Approved</message>
-            <returnCode>0</returnCode>
-            <status>0</status>
-          </PagadorReturn>
-        EOXML
-      end
+    let(:response_xml) do
+      <<-EOXML
+        <?xml version="1.0" encoding="utf-8"?>
+        <PagadorReturn xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                       xmlns="https://www.pagador.com.br/webservice/pagador">
+          <amount>2</amount>
+          <message>Approved</message>
+          <returnCode>0</returnCode>
+          <status>0</status>
+        </PagadorReturn>
+      EOXML
+    end
 
-      it "requests the order cancellation" do
-        Braspag::CreditCard.void(order_id)
-        request.body.should == {"order"=>"order-id", "merchantId"=>"order-id"}
-      end
+    it "requests the order cancellation" do
+      Braspag::CreditCard.void(order_id)
+      request.body.should == {"order"=>"order-id", "merchantId"=>"order-id"}
+    end
 
-      it "returns the cancellation response" do
-        response = Braspag::CreditCard.void(order_id)
-        response.should == {
-          :amount => "2",
-          :number => nil,
-          :message => "Approved",
-          :return_code => "0",
-          :status => "0",
-          :transaction_id => nil
-        }
-      end
+    it "returns the cancellation response" do
+      response = Braspag::CreditCard.void(order_id)
+      response.should == {
+        :amount => "2",
+        :number => nil,
+        :message => "Approved",
+        :return_code => "0",
+        :status => "0",
+        :transaction_id => nil
+      }
     end
 
     context "when the order id is invalid" do

--- a/spec/credit_card_spec.rb
+++ b/spec/credit_card_spec.rb
@@ -5,7 +5,7 @@ describe Braspag::CreditCard do
   let(:braspag_service_url) { "https://homologacao.pagador.com.br" }
 
   let(:connection) { mock(
-    :merchant_id => 'order-id',
+    :merchant_id => 'merchant-id',
     :protected_card_url => 'https://www.cartaoprotegido.com.br/Services/TestEnvironment',
     :homologation? => (environment == 'homologation'),
     :production? => (environment == 'production'),
@@ -60,7 +60,7 @@ describe Braspag::CreditCard do
 
     it "request the order authorization" do
       Braspag::CreditCard.authorize(params)
-      request.body.should == {"merchantId"=>"order-id", "order"=>"", "orderId"=>"order-id", "customerName"=>"WWWWWWWWWWWWWWWWWWWWW", "amount"=>"100,00", "paymentMethod"=>997, "holder"=>"Joao Maria Souza", "cardNumber"=>"9999999999", "expiration"=>"10/12", "securityCode"=>"123", "numberPayments"=>1, "typePayment"=>0}
+      request.body.should == {"merchantId"=>"merchant-id", "order"=>"", "orderId"=>"order-id", "customerName"=>"WWWWWWWWWWWWWWWWWWWWW", "amount"=>"100,00", "paymentMethod"=>997, "holder"=>"Joao Maria Souza", "cardNumber"=>"9999999999", "expiration"=>"10/12", "securityCode"=>"123", "numberPayments"=>1, "typePayment"=>0}
     end
 
     it "returns the authorization result" do
@@ -178,7 +178,7 @@ describe Braspag::CreditCard do
 
     it "requests the order capture" do
       Braspag::CreditCard.capture("order id qualquer")
-      request.body.should == {"orderId"=>"order id qualquer", "merchantId"=>"order-id"}
+      request.body.should == {"orderId"=>"order id qualquer", "merchantId"=>"merchant-id"}
     end
 
     it "returns the capture result" do
@@ -222,7 +222,7 @@ describe Braspag::CreditCard do
 
     it "requests the order partial capture" do
       Braspag::CreditCard.partial_capture(order_id, 10.0)
-      request.body.should == {"orderId"=>"order-id", "captureAmount"=>"10,00", "merchantId"=>"order-id"}
+      request.body.should == {"orderId"=>"order-id", "captureAmount"=>"10,00", "merchantId"=>"merchant-id"}
     end
 
     it "returns the partial capture response" do
@@ -266,7 +266,7 @@ describe Braspag::CreditCard do
 
     it "requests the order cancellation" do
       Braspag::CreditCard.void(order_id)
-      request.body.should == {"order"=>"order-id", "merchantId"=>"order-id"}
+      request.body.should == {"order"=>"order-id", "merchantId"=>"merchant-id"}
     end
 
     it "returns the cancellation response" do
@@ -350,7 +350,7 @@ describe Braspag::CreditCard do
   end
 
   describe ".status" do
-    let(:operation_url) { "#{connection.braspag_url}/webservices/pagador/Pagador.asmx/GetDadosPedido" }
+    let(:operation_url) { "#{connection.braspag_url}/webservices/pagador/pedido.asmx/GetDadosPedido" }
     let(:order_id) { 'order-id' }
 
     let(:response_xml) do
@@ -372,7 +372,7 @@ describe Braspag::CreditCard do
 
     it "requests the order status" do
       Braspag::CreditCard.status(order_id)
-      request.body.should == {"order"=>"order-id", "merchantId"=>"order-id"}
+      request.body.should == { :numeroPedido => 'order-id', :loja => 'merchant-id' }
     end
 
     it "returns the status response" do

--- a/spec/credit_card_spec.rb
+++ b/spec/credit_card_spec.rb
@@ -81,7 +81,7 @@ describe Braspag::CreditCard do
         :security_code, :number_payments, :type].each do |param|
         it "raises an error when #{param} parameter is missing" do
           params[param] = nil
-          expect { Braspag::CreditCard.authorize(params) }.to raise_error Braspag::IncompleteParams
+          expect { Braspag::CreditCard.authorize(params) }.to raise_error(Braspag::IncompleteParams)
         end
       end
 
@@ -89,7 +89,7 @@ describe Braspag::CreditCard do
         before { params[:order_id] = '' }
 
         it "raises an error" do
-          expect { Braspag::CreditCard.authorize(params) }.to raise_error Braspag::InvalidOrderId
+          expect { Braspag::CreditCard.authorize(params) }.to raise_error(Braspag::InvalidOrderId)
         end
       end
 
@@ -97,7 +97,7 @@ describe Braspag::CreditCard do
         before { params[:payment_method] = 'invalid' }
 
         it "raises an error" do
-          expect { Braspag::CreditCard.authorize(params) }.to raise_error Braspag::InvalidPaymentMethod
+          expect { Braspag::CreditCard.authorize(params) }.to raise_error(Braspag::InvalidPaymentMethod)
         end
       end
 
@@ -105,7 +105,7 @@ describe Braspag::CreditCard do
         before { params[:customer_name] = 'n' * 256 }
 
         it "raises an error" do
-          expect { Braspag::CreditCard.authorize(params) }.to raise_error Braspag::InvalidCustomerName
+          expect { Braspag::CreditCard.authorize(params) }.to raise_error(Braspag::InvalidCustomerName)
         end
       end
 
@@ -113,7 +113,7 @@ describe Braspag::CreditCard do
         before { params[:holder] = 'h' * 101 }
 
         it "raises an error" do
-          expect { Braspag::CreditCard.authorize(params) }.to raise_error Braspag::InvalidHolder
+          expect { Braspag::CreditCard.authorize(params) }.to raise_error(Braspag::InvalidHolder)
         end
       end
 
@@ -121,7 +121,7 @@ describe Braspag::CreditCard do
         before { params[:expiration] = '2011/19/19' }
 
         it "raises an error" do
-          expect { Braspag::CreditCard.authorize(params) }.to raise_error Braspag::InvalidExpirationDate
+          expect { Braspag::CreditCard.authorize(params) }.to raise_error(Braspag::InvalidExpirationDate)
         end
       end
 
@@ -129,7 +129,7 @@ describe Braspag::CreditCard do
         before { params[:security_code] = '12345' }
 
         it "raises an error" do
-          expect { Braspag::CreditCard.authorize(params) }.to raise_error Braspag::InvalidSecurityCode
+          expect { Braspag::CreditCard.authorize(params) }.to raise_error(Braspag::InvalidSecurityCode)
         end
       end
 
@@ -137,7 +137,7 @@ describe Braspag::CreditCard do
         before { params[:security_code] = '' }
 
         it "raises an error" do
-          expect { Braspag::CreditCard.authorize(params) }.to raise_error Braspag::InvalidSecurityCode
+          expect { Braspag::CreditCard.authorize(params) }.to raise_error(Braspag::InvalidSecurityCode)
         end
       end
 
@@ -145,7 +145,7 @@ describe Braspag::CreditCard do
         before { params[:number_payments] = 100 }
 
         it "raises an error" do
-          expect { Braspag::CreditCard.authorize(params) }.to raise_error Braspag::InvalidNumberPayments
+          expect { Braspag::CreditCard.authorize(params) }.to raise_error(Braspag::InvalidNumberPayments)
         end
       end
 
@@ -153,7 +153,7 @@ describe Braspag::CreditCard do
         before { params[:number_payments] = 0 }
 
         it "raises an error" do
-          expect { Braspag::CreditCard.authorize(params) }.to raise_error Braspag::InvalidNumberPayments
+          expect { Braspag::CreditCard.authorize(params) }.to raise_error(Braspag::InvalidNumberPayments)
         end
       end
     end

--- a/spec/credit_card_spec.rb
+++ b/spec/credit_card_spec.rb
@@ -26,6 +26,8 @@ describe Braspag::CreditCard do
   end
 
   describe ".authorize" do
+    let(:operation_url) { "#{connection.braspag_url}/webservices/pagador/Pagador.asmx/Authorize" }
+
     let(:params) { {
       :order_id => "um order id",
       :customer_name => "W" * 21,
@@ -39,42 +41,38 @@ describe Braspag::CreditCard do
       :type => 0
     } }
 
-    let(:params_with_merchant_id) { params.merge(:merchant_id => merchant_id) }
-    let(:operation_url) { "#{connection.braspag_url}/webservices/pagador/Pagador.asmx/Authorize" }
 
-    context "with valid params" do
-      let(:response_xml) do
-        <<-EOXML
-        <?xml version="1.0" encoding="utf-8"?>
-        <PagadorReturn xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                       xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-                       xmlns="https://www.pagador.com.br/webservice/pagador">
-          <amount>5</amount>
-          <message>Transaction Successful</message>
-          <authorisationNumber>733610</authorisationNumber>
-          <returnCode>7</returnCode>
-          <status>2</status>
-          <transactionId>0</transactionId>
-        </PagadorReturn>
-        EOXML
-      end
+    let(:response_xml) do
+      <<-EOXML
+      <?xml version="1.0" encoding="utf-8"?>
+      <PagadorReturn xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns="https://www.pagador.com.br/webservice/pagador">
+        <amount>5</amount>
+        <message>Transaction Successful</message>
+        <authorisationNumber>733610</authorisationNumber>
+        <returnCode>7</returnCode>
+        <status>2</status>
+        <transactionId>0</transactionId>
+      </PagadorReturn>
+      EOXML
+    end
 
-      it "should return a Hash" do
-        response = Braspag::CreditCard.authorize(params)
-        response.should == {
-          :amount => "5",
-          :message => "Transaction Successful",
-          :number => "733610",
-          :return_code => "7",
-          :status => "2",
-          :transaction_id => "0"
-        }
-      end
+    it "posts the required data for the transaction" do
+      Braspag::CreditCard.authorize(params)
+      request.body.should == {"merchantId"=>"um id qualquer", "order"=>"", "orderId"=>"um order id", "customerName"=>"WWWWWWWWWWWWWWWWWWWWW", "amount"=>"100,00", "paymentMethod"=>997, "holder"=>"Joao Maria Souza", "cardNumber"=>"9999999999", "expiration"=>"10/12", "securityCode"=>"123", "numberPayments"=>1, "typePayment"=>0}
+    end
 
-      it "should post transation info" do
-        Braspag::CreditCard.authorize(params)
-        request.body.should == {"merchantId"=>"um id qualquer", "order"=>"", "orderId"=>"um order id", "customerName"=>"WWWWWWWWWWWWWWWWWWWWW", "amount"=>"100,00", "paymentMethod"=>997, "holder"=>"Joao Maria Souza", "cardNumber"=>"9999999999", "expiration"=>"10/12", "securityCode"=>"123", "numberPayments"=>1, "typePayment"=>0}
-      end
+    it "returns a hash" do
+      response = Braspag::CreditCard.authorize(params)
+      response.should == {
+        :amount => "5",
+        :message => "Transaction Successful",
+        :number => "733610",
+        :return_code => "7",
+        :status => "2",
+        :transaction_id => "0"
+      }
     end
   end
 

--- a/spec/credit_card_spec.rb
+++ b/spec/credit_card_spec.rb
@@ -137,6 +137,24 @@ describe Braspag::CreditCard do
         end
       end
 
+      context "when expiration is in valid format with invalid date" do
+        before { params[:expiration] = '2015/19' }
+
+        it "raises an error" do
+          expect { Braspag::CreditCard.authorize(params) }.to raise_error(Braspag::InvalidExpirationDate)
+        end
+      end
+
+      ['01/15', '01/2015'].each do |expiration|
+        context "when expiration is in #{expiration} format" do
+          before { params[:expiration] = expiration }
+
+          it "raises no error" do
+            expect { Braspag::CreditCard.authorize(params) }.not_to raise_error
+          end
+        end
+      end
+
       context "when security code is too long" do
         before { params[:security_code] = '12345' }
 


### PR DESCRIPTION
This PR introduces the following changes:
  - A `.status` method in `Braspag::CreditCard` to fetch the current status of an order.
  - Some refactoring in this class and in its spec.