### PR TITLE
Bump savon and httpi to lastest version

### DIFF
--- a/baby-braspag.gemspec
+++ b/baby-braspag.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'httpi', '~> 2.4.0'
+  s.add_dependency 'httpi', '~> 2.3'
   s.add_dependency 'json', '>= 1.6.1'
   s.add_dependency 'nokogiri', '~> 1.6.1'
   s.add_dependency 'savon', '~> 2.11.0'

--- a/baby-braspag.gemspec
+++ b/baby-braspag.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'httpi', '~> 2.3'
+  s.add_dependency 'httpi', '~> 2.3.0'
   s.add_dependency 'json', '>= 1.6.1'
   s.add_dependency 'nokogiri', '~> 1.6.1'
   s.add_dependency 'savon', '~> 2.11.0'

--- a/baby-braspag.gemspec
+++ b/baby-braspag.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'httpi', '>= 0.9.6'
+  s.add_dependency 'httpi', '~> 2.4.0'
   s.add_dependency 'json', '>= 1.6.1'
   s.add_dependency 'nokogiri', '~> 1.6.1'
-  s.add_dependency 'savon', '~> 2.3.2'
+  s.add_dependency 'savon', '~> 2.11.0'
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", '~> 2.12.0'


### PR DESCRIPTION
This PR introduces the following changes:

* [Update savon version from v2.3.0 to v2.11.0 changes](https://github.com/savonrb/savon/compare/v2.3.0...v2.11.0)
* [Update httpi version from v0.9.6 to v2.3.0 changes](https://github.com/savonrb/httpi/compare/v0.9.6...v2.4.0)